### PR TITLE
Clarify where to get the qubes version

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,8 +1,11 @@
-#### Qubes OS version (e.g., `R3.2`):
+#### Qubes OS version:
+<!-- (e.g., `R3.2`)
+     You can get it from the dom0 terminal with the command
+         cat /etc/qubes-release
+  -->
 
-#### Affected TemplateVMs (e.g., `fedora-23`, if applicable):
-
-
+#### Affected TemplateVMs: 
+<!-- (e.g., `fedora-23`, if applicable) -->
 ---
 
 ### Steps to reproduce the behavior:


### PR DESCRIPTION
Problem:
1. I want to know which qubes version I have but I needed to google for how to find this out
2. I wanted to write a more extensive documentation on how to get the version

Solution:
1. Add a command from https://www.qubes-os.org/doc/version-scheme/#check-installed-version
2. Use html comments to hide explanations from the actual issue

I am open for suggestions and can understand if you do not like the change.