### PR TITLE
Change default branch to 4.3 for bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -15,7 +15,7 @@ body:
       options:
         - Qubes OS 4.2
         - Qubes OS 4.3
-      default: 0
+      default: 1
       multiple: true
   - type: textarea
     id: summary


### PR DESCRIPTION
The amount of issues opened to R4.2 since the release of R4.3 is very low:

- [is:issue label:affects-4.2 -label:affects-4.3](https://github.com/QubesOS/qubes-issues/issues?q=is%3Aissue%20label%3Aaffects-4.2%20-label%3Aaffects-4.3)

While the amount of issues opened to R4.3 is very high:

- [is:issue -label:affects-4.2 label:affects-4.3](https://github.com/QubesOS/qubes-issues/issues?q=is%3Aissue%20-label%3Aaffects-4.2%20label%3Aaffects-4.3)